### PR TITLE
Added tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Tests
+
+on:
+    pull_request: ~
+    push:
+        branches:
+            - main
+
+jobs:
+    test:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ ubuntu-latest ]
+                php: [ '8.2', '8.3' ]
+
+        name: Test with php ${{ matrix.php }} on ${{ matrix.os }}
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v4
+                with:
+                    persist-credentials: false
+                    fetch-depth: 0
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    tools: composer:v2
+            #          coverage: xdebug
+
+            -   name: Get composer cache directory
+                id: composer-cache
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            -   name: Cache dependencies
+                uses: actions/cache@v4
+                with:
+                    path: ${{ steps.composer-cache.outputs.dir }}
+                    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: ${{ runner.os }}-composer-
+
+            -   name: Install Dependencies
+                run: composer update --no-interaction --prefer-dist
+
+            -   name: Run tests
+                run: ./vendor/bin/pest


### PR DESCRIPTION
Closes #32

Also, composer.json states that PHP 8.2 is supported but tests shows it fails because typed class constants are only allowed since PHP 8.3. See #34 