### PR TITLE
Simplify html generator & Add line numbers

### DIFF
--- a/src/CommonMark/CodeBlockRenderer.php
+++ b/src/CommonMark/CodeBlockRenderer.php
@@ -15,6 +15,7 @@ class CodeBlockRenderer implements NodeRendererInterface
     public function __construct(
         private string|array|Theme $theme,
         private Phiki $phiki = new Phiki,
+        private bool $withGutter = false,
         private bool $withWrapper = false,
     ) {}
 
@@ -29,6 +30,6 @@ class CodeBlockRenderer implements NodeRendererInterface
         $grammar = $matches[0];
         $code = rtrim($node->getLiteral(), "\n");
 
-        return $this->phiki->codeToHtml($code, $grammar, $this->theme, $this->withWrapper);
+        return $this->phiki->codeToHtml($code, $grammar, $this->theme, $this->withGutter, $this->withWrapper);
     }
 }

--- a/src/CommonMark/PhikiExtension.php
+++ b/src/CommonMark/PhikiExtension.php
@@ -11,17 +11,19 @@ use Phiki\Theme\Theme;
 class PhikiExtension implements ExtensionInterface
 {
     /**
+     * @param  bool  $withGutter   Include a gutter in the generated HTML. The gutter typically contains line numbers and helps provide context for the code.
      * @param  bool  $withWrapper  Wrap the generated HTML in an additional `<div>` so that it can be styled with CSS. Useful for avoiding overflow issues.
      */
     public function __construct(
         private string|array|Theme $theme,
         private Phiki $phiki = new Phiki,
+        private bool $withGutter = false,
         private bool $withWrapper = false,
     ) {}
 
     public function register(EnvironmentBuilderInterface $environment): void
     {
         $environment
-            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->theme, $this->phiki, $this->withWrapper), 10);
+            ->addRenderer(FencedCode::class, new CodeBlockRenderer($this->theme, $this->phiki, $this->withGutter, $this->withWrapper), 10);
     }
 }

--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -20,129 +20,123 @@ class HtmlGenerator implements OutputGeneratorInterface
 
     public function generate(array $tokens): string
     {
-        $html = [];
-        $defaultTheme = Arr::first($this->themes);
-        $defaultThemeId = Arr::firstKey($this->themes);
+        return $this->withWrapper ? $this->buildWrapper($tokens) : $this->buildPre($tokens);
+    }
 
-        if ($this->withWrapper) {
-            $wrapperStyles = [
-                $defaultTheme->base()->toStyleString(),
-            ];
+    private function buildWrapper($tokens): string
+    {
+        $wrapperStyles = [$this->getDefaultTheme()->base()->toStyleString()];
 
-            foreach ($this->themes as $id => $theme) {
-                if ($id === $defaultThemeId) {
-                    continue;
-                }
-
+        foreach ($this->themes as $id => $theme) {
+            if ($id !== $this->getDefaultThemeId()) {
                 $wrapperStyles[] = $theme->base()->toCssVarString($id);
             }
-
-            $html[] = sprintf(
-                '<div class="phiki-wrapper" style="%s"%s>',
-                implode(';', $wrapperStyles),
-                $this->grammarName ? sprintf(' data-language="%s"', $this->grammarName) : '',
-            );
         }
 
-        $preClasses = ['phiki', $this->grammarName ? 'language-'.$this->grammarName : null, $defaultTheme->name];
+        return sprintf(
+            '<div class="phiki-wrapper"%s style="%s">%s</div>',
+            $this->grammarName ? " data-language=\"$this->grammarName\"" : null,
+            implode(';', $wrapperStyles),
+            $this->buildPre($tokens)
+        );
+    }
 
-        if (count($this->themes) > 1) {
-            $preClasses[] = 'phiki-themes';
+    private function buildPre($tokens): string
+    {
+        $preClasses = array_filter([
+            'phiki',
+            $this->grammarName ? "language-$this->grammarName" : null,
+            $this->getDefaultTheme()->name,
+            count($this->themes) > 1 ? 'phiki-themes' : null,
+        ]);
 
-            foreach ($this->themes as $theme) {
-                if ($theme === $defaultTheme) {
-                    continue;
-                }
-
+        foreach ($this->themes as $theme) {
+            if ($theme !== $this->getDefaultTheme()) {
                 $preClasses[] = $theme->name;
             }
         }
 
-        $preStyles = [
-            $defaultTheme->base()->toStyleString(),
-        ];
+        $preStyles = [$this->getDefaultTheme()->base()->toStyleString()];
 
         foreach ($this->themes as $id => $theme) {
-            if ($id === $defaultThemeId) {
-                continue;
+            if ($id !== $this->getDefaultThemeId()) {
+                $preStyles[] = $theme->base()->toCssVarString($id);
             }
-
-            $preStyles[] = $theme->base()->toCssVarString($id);
         }
 
-        $html[] = sprintf(
-            '<pre class="%s" style="%s"%s>',
-            implode(' ', array_filter($preClasses)),
+        return sprintf(
+            '<pre class="%s"%s style="%s">%s</pre>',
+            implode(' ', $preClasses),
+            $this->grammarName ? " data-language=\"$this->grammarName\"" : null,
             implode(';', $preStyles),
-            $this->grammarName ? sprintf(' data-language="%s"', $this->grammarName) : '',
+            $this->buildCode($tokens)
         );
+    }
 
-        $html[] = '<code>';
-
+    private function buildCode(array $tokens): string
+    {
         foreach ($tokens as $i => $line) {
-            $html[] = sprintf(
-                '<span class="line" data-line="%d">',
-                $i + 1,
-            );
+            $output[] = $this->buildLine($line, $i);
+        }
 
-            if ($this->withGutter) {
-                $lineNumberStyle = [];
+        return '<code>' . implode($output) . '</code>';
+    }
 
-                if ($lineNumberColor = $theme->colors['editorLineNumber.foreground'] ?? null) {
-                    $lineNumberStyle[] = "color: $lineNumberColor";
-                }
+    private function buildLine(array $line, int $index): string
+    {
+        $output = [];
 
-                $lineNumberStyle[] = '-webkit-user-select: none';
-                $lineNumberStyle[] = 'user-select: none';
-            
-                $lineNumberStyles = implode('; ', $lineNumberStyle) . ';';
-            
-                $html[] = sprintf(
-                    '<span class="line-number" style="%s">%2d</span>',
-                    $lineNumberStyles,
-                    $i + 1
-                );
-            }  
+        if ($this->withGutter) {
+            $output[] = $this->buildLineNumber($index + 1);
+        }
 
-            foreach ($line as $token) {
-                if ($token->settings === []) {
-                    $html[] = sprintf(
-                        '<span class="token">%s</span>',
-                        htmlspecialchars($token->token->text),
-                    );
+        foreach ($line as $token) {
+            $output[] = $this->buildToken($token);
+        }
 
-                    continue;
-                }
+        return '<span class="line">' . implode($output) . '</span>';
+    }
 
-                $tokenStyles = [
-                    ($token->settings[$defaultThemeId] ?? null)?->toStyleString(),
-                ];
+    private function buildLineNumber(int $lineNumber): string
+    {
+        $lineNumberColor = $this->getDefaultTheme()->colors['editorLineNumber.foreground'] ?? null;
 
-                foreach ($token->settings as $id => $settings) {
-                    if ($id === $defaultThemeId) {
-                        continue;
-                    }
+        $lineNumberStyles = $lineNumberColor ? "color: $lineNumberColor; " : null;
+        $lineNumberStyles .= '-webkit-user-select: none; user-select: none;';
 
-                    $tokenStyles[] = $settings->toCssVarString($id);
-                }
+        return sprintf(
+            '<span class="line-number" style="%s">%2d</span>',
+            $lineNumberStyles,
+            $lineNumber
+        );
+    }
 
-                $html[] = sprintf(
-                    '<span class="token" style="%s">%s</span>',
-                    implode(';', array_filter($tokenStyles)),
-                    htmlspecialchars($token->token->text),
-                );
+    private function buildToken(object $token): string
+    {
+        $tokenStyles = [($token->settings[$this->getDefaultThemeId()] ?? null)?->toStyleString()];
+
+        foreach ($token->settings as $id => $settings) {
+            if ($id !== $this->getDefaultThemeId()) {
+                $tokenStyles[] = $settings->toCssVarString($id);
             }
-
-            $html[] = '</span>';
         }
 
-        $html[] = '</code>';
-        $html[] = '</pre>';
+        $styleString = implode(';', array_filter($tokenStyles));
 
-        if ($this->withWrapper) {
-            $html[] = '</div>';
-        }
+        return sprintf(
+            '<span class="token"%s>%s</span>',
+            $styleString ? " style=\"$styleString\"" : null,
+            htmlspecialchars($token->token->text)
+        );
+    }
 
-        return implode('', $html);
+    private function getDefaultTheme(): ParsedTheme
+    {
+        return Arr::first($this->themes);
+    }
+
+    private function getDefaultThemeId(): string
+    {
+        return Arr::firstKey($this->themes);
     }
 }

--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -86,12 +86,23 @@ class HtmlGenerator implements OutputGeneratorInterface
             );
 
             if ($this->withGutter) {
+                $lineNumberStyle = [];
+
+                if ($lineNumberColor = $theme->colors['editorLineNumber.foreground'] ?? null) {
+                    $lineNumberStyle[] = "color: $lineNumberColor";
+                }
+
+                $lineNumberStyle[] = '-webkit-user-select: none';
+                $lineNumberStyle[] = 'user-select: none';
+            
+                $lineNumberStyles = implode('; ', $lineNumberStyle) . ';';
+            
                 $html[] = sprintf(
-                    '<span class="line-number" style="color: %s; -webkit-user-select: none; user-select: none;">%2d</span>',
-                    $defaultTheme->colors['editorLineNumber.foreground'],
-                    $i + 1,
+                    '<span class="line-number" style="%s">%2d</span>',
+                    $lineNumberStyles,
+                    $i + 1
                 );
-            }
+            }  
 
             foreach ($line as $token) {
                 if ($token->settings === []) {

--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -14,6 +14,7 @@ class HtmlGenerator implements OutputGeneratorInterface
     public function __construct(
         protected ?string $grammarName,
         protected array $themes,
+        protected bool $withGutter = false,
         protected bool $withWrapper = false,
     ) {}
 
@@ -79,12 +80,18 @@ class HtmlGenerator implements OutputGeneratorInterface
         $html[] = '<code>';
 
         foreach ($tokens as $i => $line) {
-            $html[] = '<span class="line">';
-
             $html[] = sprintf(
-                '<span class="line-number" style="-webkit-user-select: none; user-select: none;">%2d</span>',
+                '<span class="line" data-line="%d">',
                 $i + 1,
             );
+
+            if ($this->withGutter) {
+                $html[] = sprintf(
+                    '<span class="line-number" style="color: %s; -webkit-user-select: none; user-select: none;">%2d</span>',
+                    $defaultTheme->colors['editorLineNumber.foreground'],
+                    $i + 1,
+                );
+            }
 
             foreach ($line as $token) {
                 if ($token->settings === []) {

--- a/src/Generators/HtmlGenerator.php
+++ b/src/Generators/HtmlGenerator.php
@@ -79,8 +79,10 @@ class HtmlGenerator implements OutputGeneratorInterface
         $html[] = '<code>';
 
         foreach ($tokens as $i => $line) {
+            $html[] = '<span class="line">';
+
             $html[] = sprintf(
-                '<span class="line" data-line="%d">',
+                '<span class="line-number" style="-webkit-user-select: none; user-select: none;">%2d</span>',
                 $i + 1,
             );
 

--- a/src/Phiki.php
+++ b/src/Phiki.php
@@ -46,9 +46,10 @@ class Phiki
     }
 
     /**
+     * @param  bool  $withGutter   Include a gutter in the generated HTML. The gutter typically contains line numbers and helps provide context for the code.
      * @param  bool  $withWrapper  Wrap the generated HTML in an additional `<div>` so that it can be styled with CSS. Useful for avoiding overflow issues.
      */
-    public function codeToHtml(string $code, string|Grammar $grammar, string|array|Theme $theme, bool $withWrapper = false): string
+    public function codeToHtml(string $code, string|Grammar $grammar, string|array|Theme $theme, bool $withGutter = false, bool $withWrapper = false): string
     {
         $tokens = $this->codeToHighlightedTokens($code, $grammar, $theme);
         $generator = new HtmlGenerator(
@@ -57,6 +58,7 @@ class Phiki
                 default => $this->environment->resolveGrammar($grammar)->name,
             },
             $this->wrapThemes($theme),
+            $withGutter,
             $withWrapper,
         );
 


### PR DESCRIPTION
Hello @ryangjchandler,

First, I want to express my gratitude for bringing such a difficult project to life! :)

I see that line numbers are currently supported through the `data-line` attribute, which is then enabled with CSS to display the numbers in the generated HTML. However, what if we generate the line numbers directly in the HTML? By using an inline `user-select: none` style to prevent selection and adding a `line-number` class so we enable further customization while simplifying the structure.


Further, we need a way to enable (should be disabled by default) line numbers but I'll let you decide on how would you do it. Here's an idea..

```php
$html = $phiki->codeToHtml(
    <<<'PHP'
    echo "Hello, world!";
    PHP,
    Grammar::Php,
    Theme::GithubDark,
)->withLineNumbers(startAt: 5); // also nice to have option for line number start
``` 

**Output:**
```html
<span class="line">
  <span class="line-number" style="-webkit-user-select: none; user-select: none;"> 5</span>
  <span class="token" style="color: #79b8ff;">echo</span>
  <span class="token"> </span>
  <span class="token" style="color: #9ecbff;">"</span>
  <span class="token" style="color: #9ecbff;">Hello, world!</span>
  <span class="token" style="color: #9ecbff;">"</span>
  <span class="token">;</span>
  <span class="token"> </span>
 </span>
```

**Customization:**
```css
pre code .line-number {
    margin-right: 1rem;
    /* Suggestion: would be also nice to add the theme base color as inline style with an hex alpha value */
    color: #7683904D; /*(4D = 30% transperency)*/
    text-align: right;
}
``` 

Let me know your thoughts on this approach!