### PR TITLE
Assume `txt` if grammar detection fails

### DIFF
--- a/src/CommonMark/CodeBlockRenderer.php
+++ b/src/CommonMark/CodeBlockRenderer.php
@@ -35,7 +35,7 @@ class CodeBlockRenderer implements NodeRendererInterface
     protected function detectGrammar(FencedCode $node, string $code): Grammar|string
     {
         if (! isset($node->getInfoWords()[0]) || $node->getInfoWords()[0] === '') {
-            return $this->phiki->detectGrammar($code);
+            return $this->phiki->detectGrammar($code) ?? 'txt';
         }
 
         preg_match('/[a-zA-Z]+/', $node->getInfoWords()[0], $matches);


### PR DESCRIPTION
Hi Ryan,

I'm loving this package! I saw your announcement of v1.0 and I'm currently trying it out to see if I can replace Shiki with this, but I'm bumping into a couple of issues. 

I made a quick fork to see if I could fix and PR the most common exception I seemed to be getting was related to the fallback for grammar detection, which didn't seem to work although this was noted as added in #41:

> The CommonMark plugin has also been updated to fallback to auto-detection if a grammar isn't defined in the code block directly. If nothing matches, it will fallback to the txt language.

Going by the return type of `detectGrammar`, I'm guessing this was an accidental omission? This PR addresses that.

I've got a couple of blog posts written in Markdown that I'm bulk running this on, and this was the only exception I was getting. I do also appear to have some issues with the parser "hanging" (probably caught in an infinite loop somewhere...) – if I figure out what's going wrong, what's the best way to report that?

Cheers!