### PR TITLE
Fix memory exhaustion from unbounded line ranges in MetaTransformer

### DIFF
--- a/src/Adapters/CommonMark/Transformers/MetaTransformer.php
+++ b/src/Adapters/CommonMark/Transformers/MetaTransformer.php
@@ -7,8 +7,10 @@ use Phiki\Transformers\AbstractTransformer;
 
 class MetaTransformer extends AbstractTransformer
 {
+    /** @var array<int, array{int, int}> List of inclusive [start, end] line ranges. */
     protected array $highlights = [];
 
+    /** @var array<int, array{int, int}> List of inclusive [start, end] line ranges. */
     protected array $focuses = [];
 
     public function preprocess(string $code): string
@@ -29,11 +31,13 @@ class MetaTransformer extends AbstractTransformer
 
     public function line(Element $span, array $tokens, int $index): Element
     {
-        if (in_array($index + 1, $this->highlights, true)) {
+        $lineNumber = $index + 1;
+
+        if ($this->containsLine($this->highlights, $lineNumber)) {
             $span->properties->get('class')->add('highlight');
         }
 
-        if (in_array($index + 1, $this->focuses, true)) {
+        if ($this->containsLine($this->focuses, $lineNumber)) {
             $span->properties->get('class')->add('focus');
         }
 
@@ -56,48 +60,56 @@ class MetaTransformer extends AbstractTransformer
             null
         );
 
-        if (! $highlights && ! $focuses) {
-            return;
+        $this->highlights = $this->parseLineRanges($highlights);
+        $this->focuses = $this->parseLineRanges($focuses);
+    }
+
+    /**
+     * Parse a comma-separated list of line numbers and ranges (e.g. "2,4-8") into
+     * a list of inclusive [start, end] pairs.
+     *
+     * Ranges are deliberately never expanded into individual line numbers, since
+     * the meta string is user-controlled and a range such as "1-100000000" would
+     * otherwise exhaust memory. Reversed ranges (e.g. "5-2") are ignored, and
+     * entries that don't match a real line (e.g. "0" or "abc") never match anything.
+     *
+     * @return array<int, array{int, int}>
+     */
+    protected function parseLineRanges(?string $spec): array
+    {
+        if (! $spec) {
+            return [];
         }
 
-        $highlights = array_map(
-            fn (array $part) => count($part) > 1 ? $part : $part[0],
-            array_map(
-                fn (string $part) => array_map(fn (string $number) => intval($number), explode('-', trim($part))),
-                explode(',', $highlights)
-            )
-        );
+        $ranges = [];
 
-        foreach ($highlights as $part) {
-            if (is_array($part)) {
-                $this->highlights = array_merge($this->highlights, range($part[0], $part[1]));
-            } else {
-                $this->highlights[] = $part;
+        foreach (explode(',', $spec) as $part) {
+            $bounds = explode('-', trim($part));
+
+            $start = intval($bounds[0]);
+            $end = isset($bounds[1]) ? intval($bounds[1]) : $start;
+
+            if ($end < $start) {
+                continue;
+            }
+
+            $ranges[] = [$start, $end];
+        }
+
+        return $ranges;
+    }
+
+    /**
+     * @param  array<int, array{int, int}>  $ranges
+     */
+    protected function containsLine(array $ranges, int $lineNumber): bool
+    {
+        foreach ($ranges as [$start, $end]) {
+            if ($lineNumber >= $start && $lineNumber <= $end) {
+                return true;
             }
         }
 
-        $this->highlights = array_unique($this->highlights);
-
-        if (! $focuses) {
-            return;
-        }
-
-        $focuses = array_map(
-            fn (array $part) => count($part) > 1 ? $part : $part[0],
-            array_map(
-                fn (string $part) => array_map(fn (string $number) => intval($number), explode('-', trim($part))),
-                explode(',', $focuses)
-            )
-        );
-
-        foreach ($focuses as $part) {
-            if (is_array($part)) {
-                $this->focuses = array_merge($this->focuses, range($part[0], $part[1]));
-            } else {
-                $this->focuses[] = $part;
-            }
-        }
-
-        $this->focuses = array_unique($this->focuses);
+        return false;
     }
 }

--- a/tests/Adapters/CommonMark/Transformers/MetaTransformerTest.php
+++ b/tests/Adapters/CommonMark/Transformers/MetaTransformerTest.php
@@ -118,16 +118,38 @@ it('ignores invalid line numbers', function () {
     expect(substr_count($output, '<span class="line focus">'))->toBe(0);
 });
 
-it('ignores invalid ranges', function () {
-    $output = markdown(<<<'MD'
-    ```php {2-1,3-2}{2-1,3-2}
+it('ignores reversed ranges', function () {
+    $highlighted = markdown(<<<'MD'
+    ```php {2-1,3-2}
     class A {}
     function b() {}
     ```
     MD);
 
-    expect(substr_count($output, '<span class="line highlight">'))->toBe(0);
-    expect(substr_count($output, '<span class="line focus">'))->toBe(0);
+    $focused = markdown(<<<'MD'
+    ```php {}{2-1,3-2}
+    class A {}
+    function b() {}
+    ```
+    MD);
+
+    expect(substr_count($highlighted, '<span class="line highlight">'))->toBe(0);
+    expect(substr_count($focused, '<span class="line focus">'))->toBe(0);
+});
+
+it('does not expand ranges that extend beyond the code', function () {
+    $memoryBefore = memory_get_peak_usage();
+
+    $output = markdown(<<<'MD'
+    ```php {1-100000000}{1-100000000}
+    class A {}
+    function b() {}
+    ```
+    MD);
+
+    // Expanding the range into individual line numbers would need over 2 GB.
+    expect(memory_get_peak_usage() - $memoryBefore)->toBeLessThan(16 * 1024 * 1024);
+    expect(substr_count($output, '<span class="line highlight focus">'))->toBe(2);
 });
 
 it('can highlight and focus the same line', function () {


### PR DESCRIPTION
Line ranges in the code fence meta string (e.g. `{1-5}`) were expanded with `range()`, so `{1-100000000}` attempted a ~2 GB allocation, which can cause a fatal error in PHP ( depending on config ).

Ranges are now stored as [start, end] pairs and checked per line instead of being expanded.  Reversed ranges (e.g. `{5-2}`) are ignored; previously they were expanded in descending order and highlighted.

Tests were updated for this as well:

- Add regression test for an oversized range
- Improved the reversed-range test